### PR TITLE
fix: the sticker plugin accepts user-controlled urls... in sticker.js

### DIFF
--- a/lib/sticker.js
+++ b/lib/sticker.js
@@ -3,6 +3,10 @@ const { Sticker, StickerTypes } = require('wa-sticker-formatter');
 async function createSticker(img, url, packname = 'Bot', author = 'Bot') {
     let media = img;
     if (!media && url) {
+        const parsed = new URL(url);
+        if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('Invalid URL protocol');
+        const h = parsed.hostname;
+        if (/^(localhost|127\.|0\.0\.0\.0|169\.254\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(h)) throw new Error('URL not allowed');
         const res = await fetch(url);
         if (!res.ok) throw new Error(await res.text());
         media = await res.buffer();


### PR DESCRIPTION
## Summary
Fix high severity security issue in `lib/sticker.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/sticker.js:5` |
| **Assessment** | Likely exploitable |

**Description**: The sticker plugin accepts user-controlled URLs without validation, allowing attackers to fetch content from internal network services, cloud metadata endpoints, or other restricted resources.

## Evidence

**Exploitation scenario**: Send sticker command with malicious URL: `createSticker(null, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')` to access AWS credentials or `http://localhost:6379` to probe for.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `lib/sticker.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
